### PR TITLE
Fix renaming of mkbranch to make-branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ review-tickets
 get-attachment get <ticket-number> # Gets latest attachment from ticket
 tch-ticket works :)
 get-attachment apply <ticket-number> # Gets latest attachment from ticket, applies it to the current git reposiory, and commits it with an appropriate message.
-mkbranch <branch-name> # Creates an svn branch with the given name
+make-branch <branch-name> # Creates an svn branch with the given name
 force-build # Force-builds the current git branch, assuming it has been push'd (with dcommit) to svn
 ```

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='twisted-dev-tools',
-    version='0.0.2',
+    version='0.0.3',
     url='https://github.com/twisted/twisted-dev-tools',
     description="Tools for twisted development",
     license='MIT',
@@ -11,7 +11,7 @@ setup(
     packages=['twisted_tools', 'twisted_tools.scripts', 'twisted_tools.test'],
     scripts=[
         'bin/force-build',
-        'bin/mkbranch',
+        'bin/make-branch',
         'bin/fetch-ticket',
         'bin/review-tickets',
         'bin/get-attachment',


### PR DESCRIPTION
Problem
======

It looks like mkbranch script was renamed to make-branch but there was no update in setup.py and readme

Running `pip install -e .` will get something like

```
    Adding twisted-dev-tools 0.0.2 to easy-install.pth file
    Installing force-build script to /home/adi/chevah/twisted/build/bin
    error: [Errno 2] No such file or directory: '/home/adi/chevah/twisted-dev-tools/bin/mkbranch'
```

Why we got this
============

Nobody bother to see if master can still be installed.


Changes
=======

Update setup.py and readme


How to test
=========

In a virtualenv, run `pip install -e /path/to/you/dev-tools/clone`  You should see that package is successfully installed.

Please let me know if I did something wrong :) Thanks!
