### PR TITLE
Add support to trigger a specific builder. Auto-open url on request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ review-tickets
 get-attachment get <ticket-number> # Gets latest attachment from ticket
 tch-ticket works :)
 get-attachment apply <ticket-number> # Gets latest attachment from ticket, applies it to the current git reposiory, and commits it with an appropriate message.
-mkbranch <branch-name> # Creates an svn branch with the given name
+make-branch <branch-name> # Creates an svn branch with the given name
 force-build # Force-builds the current git branch, assuming it has been push'd (with dcommit) to svn
 ```

--- a/bin/force-build
+++ b/bin/force-build
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 """
-Force the Twisted buildmaster to run a builds on all supported builders for
-a particular branch.
+Triggers Twisted buildmaster builds for a branch. By default it only operates
+with supported builders.
 """
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='twisted-dev-tools',
-    version='0.0.2',
+    version='0.0.3',
     url='https://github.com/twisted/twisted-dev-tools',
     description="Tools for twisted development",
     license='MIT',
@@ -11,7 +11,7 @@ setup(
     packages=['twisted_tools', 'twisted_tools.scripts', 'twisted_tools.test'],
     scripts=[
         'bin/force-build',
-        'bin/mkbranch',
+        'bin/make-branch',
         'bin/fetch-ticket',
         'bin/review-tickets',
         'bin/get-attachment',

--- a/twisted_tools/buildbot.py
+++ b/twisted_tools/buildbot.py
@@ -3,6 +3,7 @@ import urllib
 import treq
 import twisted
 
+BASE_URL = 'http://buildbot.twistedmatrix.com'
 USER_AGENT = (
     "force-builds (%(name)s; %(platform)s) Twisted/%(twisted)s "
     "Python/%(python)s" % dict(
@@ -11,15 +12,29 @@ USER_AGENT = (
 
 
 
-def getURLForBranch(branch):
+def _getURLForBranch(branch, builder=None, supported=True):
     """
-    Get URL for build results corresponding to a branch.
+    Get URL for build results corresponding to a branch and an optional
+    builder.
+
+    When no builder is specified it returns the link to supported builders.
     """
-    return 'http://buildbot.twistedmatrix.com/boxes-supported?branch=%s' % (urllib.quote(branch),)
+    if supported:
+        base = 'boxes-supported?'
+    else:
+        base = 'boxes-unsupported?'
+
+    if builder:
+        base += 'builder=%s&' % (builder,)
+
+    return '/%sbranch=%s' % (base, urllib.quote(branch))
 
 
 
-def forceBuild(branch, reason, tests=None, reactor=None):
+def forceBuild(
+        branch, reason, tests=None, reactor=None, builder=None,
+        get_method=None, supported=True,
+        ):
     """
     Force a build of a given branch.
 
@@ -28,25 +43,43 @@ def forceBuild(branch, reason, tests=None, reactor=None):
     if not branch.startswith('/branches/'):
         branch = '/branches/' + branch
 
+    if not get_method:
+        get_method = treq.get
+
+    if not builder:
+        target = '/builders/_all/forceall'
+        selected_builder = ''
+    else:
+        target = '/builders/_selected/forceselected'
+        selected_builder = builder
+
+    if supported:
+        force_scheduler = 'force-supported'
+    else:
+        force_scheduler = 'force-unsupported'
+
     args = [
         ('username', 'twisted'),
         ('passwd', 'matrix'),
-        ('forcescheduler', 'force-supported'),
+        ('forcescheduler', force_scheduler),
         ('revision', ''),
         ('submit', 'Force Build'),
         ('branch', branch),
-        ('reason', reason)]
+        ('reason', reason),
+        ('selected', selected_builder),
+        ]
 
     if tests is not None:
         args += [('test-case-name', tests)]
 
-    url = "http://buildbot.twistedmatrix.com/builders/_all/forceall"
+    url = BASE_URL + target
     url = url + '?' + '&'.join([k + '=' + urllib.quote(v) for (k, v) in args])
     headers = {'user-agent': [USER_AGENT]}
     # We don't actually care about the result and buildbot returns a
     # relative redirect here. Until recently (#5434) twisted didn't
     # handle them, so avoid following the redirect to support released
     # versions of twisted.
-    d = treq.get(url, headers, allow_redirects=False, reactor=reactor)
-    d.addCallback(lambda _: getURLForBranch(branch))
+    d = get_method(url, headers, allow_redirects=False, reactor=reactor)
+    d.addCallback(
+        lambda _: BASE_URL + _getURLForBranch(branch, builder, supported))
     return d

--- a/twisted_tools/buildbot.py
+++ b/twisted_tools/buildbot.py
@@ -3,7 +3,7 @@ import urllib
 import treq
 import twisted
 
-BASE_URL = 'http://buildbot.twistedmatrix.com'
+BASE_URL = 'https://buildbot.twistedmatrix.com'
 USER_AGENT = (
     "force-builds (%(name)s; %(platform)s) Twisted/%(twisted)s "
     "Python/%(python)s" % dict(
@@ -12,7 +12,7 @@ USER_AGENT = (
 
 
 
-def _getURLForBranch(branch, builder=None, supported=True):
+def _getURLForBranch(branch, builder='', supported=True):
     """
     Get URL for build results corresponding to a branch and an optional
     builder.
@@ -20,10 +20,11 @@ def _getURLForBranch(branch, builder=None, supported=True):
     When no builder is specified it returns the link to supported builders.
     """
     if supported:
-        base = 'boxes-supported?'
+        base = 'boxes-supported'
     else:
-        base = 'boxes-unsupported?'
-
+        base = 'boxes-unsupported'
+    base += '?'
+    
     if builder:
         base += 'builder=%s&' % (builder,)
 

--- a/twisted_tools/scripts/forcebuild.py
+++ b/twisted_tools/scripts/forcebuild.py
@@ -1,5 +1,5 @@
 """
-Command line adapter for L{buildot.forceBuild}.
+Command line adapter for triggering Buildbot builds.
 """
 
 import os, pwd

--- a/twisted_tools/test/test_buildbot.py
+++ b/twisted_tools/test/test_buildbot.py
@@ -1,0 +1,182 @@
+from twisted.trial.unittest import TestCase
+from twisted.internet import defer
+
+from twisted_tools import buildbot
+
+
+
+class BuildbotTests(TestCase):
+    """
+    Tests for L{builbot} helpers.
+    """
+
+    def setUp(self):
+        super(BuildbotTests, self).setUp()
+        # Captured requests during test run.
+        self.requests = []
+
+
+    def riggedGetMethod(
+            self, url, headers, allow_redirects=False, reactor=None):
+        """
+        Fake treq.get method to capture GET requests in tests.
+        """
+        self.requests.append({
+            'url': url,
+            'headers': headers,
+            'allow_redirects': allow_redirects,
+            'reactor': reactor,
+            })
+        return defer.succeed(None)
+
+
+    def assertBuilbotPath(self, expected_path, url):
+        """
+        Check that C{url} is a buildbot url for C{expected_path}.
+        """
+        _, path = url.split(buildbot.BASE_URL)
+        self.assertEqual(expected_path, path)
+
+
+    def assertBuildbotRequest(self, path, branch, reason, builder, scheduler):
+        """
+        Check that a buildbot request was done on C{expected_path} to trigger
+        a build for C{branch}.
+        """
+        last_request = self.requests.pop(0)
+
+        # A GET request is made with buildbot option encoded in the URL.
+        _, request_path_with_args = last_request['url'].split(
+            buildbot.BASE_URL)
+        request_path, arguments = request_path_with_args.split('?', 1)
+        arguments = arguments.split('&')
+
+        self.assertEqual(path, request_path)
+        self.assertItemsEqual([
+            'branch=' + branch,
+            'reason=' + reason,
+            'selected=' + builder,
+            'forcescheduler=' + scheduler,
+            'username=twisted',
+            'passwd=matrix',
+            'submit=Force%20Build',
+            'revision=',
+            ],
+            arguments)
+
+
+    def test_forceBuildDefaultBuilder(self):
+        """
+        When no builder is specified it triggers all supported builders
+        and returns the link for all builders.
+        """
+        deferred = buildbot.forceBuild(
+            branch='/branches/some-branch',
+            reason='testing',
+            get_method=self.riggedGetMethod,
+            )
+
+        url = self.successResultOf(deferred)
+
+        self.assertBuilbotPath(
+            '/boxes-supported?branch=/branches/some-branch', url)
+        self.assertBuildbotRequest(
+            path='/builders/_all/forceall',
+            branch='/branches/some-branch',
+            reason='testing',
+            scheduler='force-supported',
+            builder='',
+            )
+
+    def test_forceBuildShortBranchName(self):
+        """
+        Branch names are expanded to SVN branch path.
+        """
+        deferred = buildbot.forceBuild(
+            branch='some-branch',
+            reason='testing',
+            get_method=self.riggedGetMethod,
+            )
+
+        url = self.successResultOf(deferred)
+
+        self.assertBuilbotPath(
+            '/boxes-supported?branch=/branches/some-branch', url)
+
+
+    def test_forceBuildSpecificBuilder(self):
+        """
+        When a builder is specified it triggers builders
+        and returns the link for the specific builder and branch.
+        """
+        deferred = buildbot.forceBuild(
+            branch='some-branch',
+            reason='testing',
+            builder='some-builder',
+            get_method=self.riggedGetMethod,
+            )
+
+        url = self.successResultOf(deferred)
+
+        self.assertBuilbotPath(
+            '/boxes-supported?builder=some-builder&branch=/branches/some-branch',
+            url)
+        self.assertBuildbotRequest(
+            path='/builders/_selected/forceselected',
+            branch='/branches/some-branch',
+            scheduler='force-supported',
+            reason='testing',
+            builder='some-builder',
+            )
+
+
+    def test_forceBuildUnsupportedBuilder(self):
+        """
+        When C{supported} flag is C{False} and no builder is specified it
+        will trigger all unsupported builders.
+        """
+        deferred = buildbot.forceBuild(
+            branch='name',
+            reason='testing',
+            supported=False,
+            get_method=self.riggedGetMethod,
+            )
+
+        url = self.successResultOf(deferred)
+
+        self.assertBuilbotPath(
+            '/boxes-unsupported?branch=/branches/name',
+            url)
+        self.assertBuildbotRequest(
+            path='/builders/_all/forceall',
+            branch='/branches/name',
+            reason='testing',
+            builder='',
+            scheduler='force-unsupported',
+            )
+
+
+    def test_forceBuildSpecificUnsupportedBuilder(self):
+        """
+        Unsupported builders need to be explicitly requested.
+        """
+        deferred = buildbot.forceBuild(
+            branch='name',
+            reason='testing',
+            builder='some-builder',
+            supported=False,
+            get_method=self.riggedGetMethod,
+            )
+
+        url = self.successResultOf(deferred)
+
+        self.assertBuilbotPath(
+            '/boxes-unsupported?builder=some-builder&branch=/branches/name',
+            url)
+        self.assertBuildbotRequest(
+            path='/builders/_selected/forceselected',
+            branch='/branches/name',
+            reason='testing',
+            builder='some-builder',
+            scheduler='force-unsupported',
+            )


### PR DESCRIPTION
Problem
======

The current force-build tools is good but could be improved.

While working on a specific problem / platform it would help a lot to be able to run only a specific builder.

Ex. only a windows builder when working on some windows stuff... only twistedchecker or documentation when cleaning docstrings.

Also, after each run, I have to manually open the browser at the specified url... this can also be improved by opening the default browser.


Changes
=======

This is build on top of #7 as otherwise I was not able to install the package for testing and development.

I have remove the  duplicated docstring from bin/force-build and twisted_tools/scripts/forcebuild.py

A `-u` flag was added to trigger unsupported builds.

I was not able to trigger a builder using the GET interface based on https://buildbot.twistedmatrix.com/builders/BUILDER/force resource. It works with POST. Maybe GET is not supported by buildbot and GET support is only a hack for Twisted... I don't know.
This is why unsupported builder need the extra `-u` argument.

`-o` flag was added to automatically open the browser.

I think that _getURLForBranch should be private so I renamed it.

To help with testing I have introduce the get_method argument. I don't know how else to do it. 

I tried to do my best to improve the tools. 
I think that this is an improvement over the current state without any regressions.

Also, in the future I would like to replace this simple GET trigger with a proper `buildot try` which would allow running patches without a commit. This would be much better for TDD.

How to test
=========

Trigger all supported builder ... normal business
```
force-build
```

Trigger all unsupported builder
```
force-build -u
```

Trigger a specific supported builder
```
force-build --builder=winxp32-py2.7
```

Trigger unsupported builder and auto open the builder page
```
force-build --builder=freebsd-9.2-amd64-python2.7 -u -o
```

Please let a look and let me know what is wrong this current patch.
Thanks!